### PR TITLE
Multiple drush versions

### DIFF
--- a/6.0/Dockerfile
+++ b/6.0/Dockerfile
@@ -1,0 +1,19 @@
+# Drush Docker Container
+FROM composer/composer
+MAINTAINER Rob Loach <robloach@gmail.com>
+
+# Add common extensions
+RUN apt-get update && apt-get install -y mysql-client
+RUN docker-php-ext-install pdo_mysql
+
+# Install Drush using Composer
+RUN composer global require drush/drush:"~6.0.0" --prefer-dist
+
+# Setup the symlink
+RUN ln -sf $COMPOSER_HOME/vendor/bin/drush.php /usr/local/bin/drush
+
+# Display which version of Drush was installed
+RUN drush --version
+
+# Update the entry point of the application
+ENTRYPOINT ["drush"]

--- a/6.1/Dockerfile
+++ b/6.1/Dockerfile
@@ -1,0 +1,19 @@
+# Drush Docker Container
+FROM composer/composer
+MAINTAINER Rob Loach <robloach@gmail.com>
+
+# Add common extensions
+RUN apt-get update && apt-get install -y mysql-client
+RUN docker-php-ext-install pdo_mysql
+
+# Install Drush using Composer
+RUN composer global require drush/drush:"~6.1.0" --prefer-dist
+
+# Setup the symlink
+RUN ln -sf $COMPOSER_HOME/vendor/bin/drush.php /usr/local/bin/drush
+
+# Display which version of Drush was installed
+RUN drush --version
+
+# Update the entry point of the application
+ENTRYPOINT ["drush"]

--- a/6.2/Dockerfile
+++ b/6.2/Dockerfile
@@ -1,0 +1,19 @@
+# Drush Docker Container
+FROM composer/composer
+MAINTAINER Rob Loach <robloach@gmail.com>
+
+# Add common extensions
+RUN apt-get update && apt-get install -y mysql-client
+RUN docker-php-ext-install pdo_mysql
+
+# Install Drush using Composer
+RUN composer global require drush/drush:"~6.2.0" --prefer-dist
+
+# Setup the symlink
+RUN ln -sf $COMPOSER_HOME/vendor/bin/drush.php /usr/local/bin/drush
+
+# Display which version of Drush was installed
+RUN drush --version
+
+# Update the entry point of the application
+ENTRYPOINT ["drush"]

--- a/6.3/Dockerfile
+++ b/6.3/Dockerfile
@@ -1,0 +1,19 @@
+# Drush Docker Container
+FROM composer/composer
+MAINTAINER Rob Loach <robloach@gmail.com>
+
+# Add common extensions
+RUN apt-get update && apt-get install -y mysql-client
+RUN docker-php-ext-install pdo_mysql
+
+# Install Drush using Composer
+RUN composer global require drush/drush:"~6.3.0" --prefer-dist
+
+# Setup the symlink
+RUN ln -sf $COMPOSER_HOME/vendor/bin/drush.php /usr/local/bin/drush
+
+# Display which version of Drush was installed
+RUN drush --version
+
+# Update the entry point of the application
+ENTRYPOINT ["drush"]

--- a/6.4/Dockerfile
+++ b/6.4/Dockerfile
@@ -1,0 +1,19 @@
+# Drush Docker Container
+FROM composer/composer
+MAINTAINER Rob Loach <robloach@gmail.com>
+
+# Add common extensions
+RUN apt-get update && apt-get install -y mysql-client
+RUN docker-php-ext-install pdo_mysql
+
+# Install Drush using Composer
+RUN composer global require drush/drush:"~6.4.0" --prefer-dist
+
+# Setup the symlink
+RUN ln -sf $COMPOSER_HOME/vendor/bin/drush.php /usr/local/bin/drush
+
+# Display which version of Drush was installed
+RUN drush --version
+
+# Update the entry point of the application
+ENTRYPOINT ["drush"]

--- a/6.5/Dockerfile
+++ b/6.5/Dockerfile
@@ -1,0 +1,19 @@
+# Drush Docker Container
+FROM composer/composer
+MAINTAINER Rob Loach <robloach@gmail.com>
+
+# Add common extensions
+RUN apt-get update && apt-get install -y mysql-client
+RUN docker-php-ext-install pdo_mysql
+
+# Install Drush using Composer
+RUN composer global require drush/drush:"~6.5.0" --prefer-dist
+
+# Setup the symlink
+RUN ln -sf $COMPOSER_HOME/vendor/bin/drush.php /usr/local/bin/drush
+
+# Display which version of Drush was installed
+RUN drush --version
+
+# Update the entry point of the application
+ENTRYPOINT ["drush"]

--- a/6.6/Dockerfile
+++ b/6.6/Dockerfile
@@ -1,0 +1,19 @@
+# Drush Docker Container
+FROM composer/composer
+MAINTAINER Rob Loach <robloach@gmail.com>
+
+# Add common extensions
+RUN apt-get update && apt-get install -y mysql-client
+RUN docker-php-ext-install pdo_mysql
+
+# Install Drush using Composer
+RUN composer global require drush/drush:"~6.6.0" --prefer-dist
+
+# Setup the symlink
+RUN ln -sf $COMPOSER_HOME/vendor/bin/drush.php /usr/local/bin/drush
+
+# Display which version of Drush was installed
+RUN drush --version
+
+# Update the entry point of the application
+ENTRYPOINT ["drush"]

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -1,0 +1,19 @@
+# Drush Docker Container
+FROM composer/composer
+MAINTAINER Rob Loach <robloach@gmail.com>
+
+# Add common extensions
+RUN apt-get update && apt-get install -y mysql-client
+RUN docker-php-ext-install pdo_mysql
+
+# Install Drush using Composer
+RUN composer global require drush/drush:"~7.0.0" --prefer-dist
+
+# Setup the symlink
+RUN ln -sf $COMPOSER_HOME/vendor/bin/drush.php /usr/local/bin/drush
+
+# Display which version of Drush was installed
+RUN drush --version
+
+# Update the entry point of the application
+ENTRYPOINT ["drush"]

--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -1,0 +1,19 @@
+# Drush Docker Container
+FROM composer/composer
+MAINTAINER Rob Loach <robloach@gmail.com>
+
+# Add common extensions
+RUN apt-get update && apt-get install -y mysql-client
+RUN docker-php-ext-install pdo_mysql
+
+# Install Drush using Composer
+RUN composer global require drush/drush:"~7.1.0" --prefer-dist
+
+# Setup the symlink
+RUN ln -sf $COMPOSER_HOME/vendor/bin/drush.php /usr/local/bin/drush
+
+# Display which version of Drush was installed
+RUN drush --version
+
+# Update the entry point of the application
+ENTRYPOINT ["drush"]

--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -1,0 +1,19 @@
+# Drush Docker Container
+FROM composer/composer
+MAINTAINER Rob Loach <robloach@gmail.com>
+
+# Add common extensions
+RUN apt-get update && apt-get install -y mysql-client
+RUN docker-php-ext-install pdo_mysql
+
+# Install Drush using Composer
+RUN composer global require drush/drush:"~8.0.0" --prefer-dist
+
+# Setup the symlink
+RUN ln -sf $COMPOSER_HOME/vendor/bin/drush.php /usr/local/bin/drush
+
+# Display which version of Drush was installed
+RUN drush --version
+
+# Update the entry point of the application
+ENTRYPOINT ["drush"]

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ Or build `drush/drush` from source:
 ```
 git clone https://github.com/RobLoach/drush-docker.git
 cd drush-docker
-docker build -t drush/drush .
+cd dev-master
+docker build -t drush/drush:dev-master .
 ```
 
 

--- a/dev-master/Dockerfile
+++ b/dev-master/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && apt-get install -y mysql-client
 RUN docker-php-ext-install pdo_mysql
 
 # Install Drush using Composer
-RUN composer global require drush/drush:~8.0.0@beta --prefer-dist
+RUN composer global require drush/drush:"dev-master" --prefer-dist
 
 # Setup the symlink
 RUN ln -sf $COMPOSER_HOME/vendor/bin/drush.php /usr/local/bin/drush


### PR DESCRIPTION
Fixes #2 by adding a Dockerfile for each stable version of drush available to install with composer (i.e.: greater than 6.0.0).

@RobLoach, once you merge this, you'll have to fix some stuff at `https://hub.docker.com/r/drush/drush/~/settings/automated-builds/` ...

1. Log in to hub.docker.com
2. Go to `https://hub.docker.com/r/drush/drush/~/settings/automated-builds/`
3. In the unlabelled table with columns "Type", "Name", "Dockerfile Location", and "Docker Tag Name":
    1. Fix the row whose "Docker Tag Name" = `latest` by setting "Dockerfile Location" = `8.0` (no trailing slash).
    2. Click the green `+` in the first row 11 times.
    3. Enter the following information in the new rows:

        Type | Name | Dockerfile Location | Docker Tag Name
        ---- | ---- | ------------------- | ---------------
        `Branch` | `master` | `dev-master` | `dev-master`
        `Branch` | `master` | `8.0` | `8.0`
        `Branch` | `master` | `7.1` | `7.1`
        `Branch` | `master` | `7.0` | `7.0`
        `Branch` | `master` | `6.6` | `6.6`
        `Branch` | `master` | `6.5` | `6.5`
        `Branch` | `master` | `6.4` | `6.4`
        `Branch` | `master` | `6.3` | `6.3`
        `Branch` | `master` | `6.2` | `6.2`
        `Branch` | `master` | `6.1` | `6.1`
        `Branch` | `master` | `6.0` | `6.0`

    4. Click `Save Changes`
    5. Trigger each build.

***

## Folder and tag naming notes

There are a few options for naming folders / tags:

* I could have named them the way [Composer](https://packagist.org/packages/drush/drush) / [the tags in `drush-ops/drush`](https://github.com/drush-ops/drush/releases) / [SemVer](http://semver.org/) refer to them (i.e.: `6.0.0`, `6.1.0`, etc.)
* I could have named them the way Drush refers to itself in `drush --version` (i.e.: `6.0`, `6.1.0`, etc.)
* I could have used Drupal-style placeholders for the Patch version element (i.e.: `6.0.x`, `6.1.x`, etc.)
* I could have left out the Patch version element entirely (i.e.: `6.0`, `6.1`, etc.).

I chose to leave out the Patch version element in my folder names and tag suggested names because:

* I'm not aware of any maintainability impacts,
* I suspect we don't want to add new tags / Dockerfiles for every patch at the current time,
* SemVer doesn't define any standard placeholders, and,
* Less typing

... however, I'm open to suggestions and happy to change it if necessary.

***

Special thanks to:

* https://getcomposer.org/doc/articles/versions.md
* http://semver.mwl.be/

... for helping me understand how Composer interprets version numbers.