### PR TITLE
Drush 6 needs the Console_Table pear.

### DIFF
--- a/6.0/Dockerfile
+++ b/6.0/Dockerfile
@@ -6,6 +6,9 @@ MAINTAINER Rob Loach <robloach@gmail.com>
 RUN apt-get update && apt-get install -y mysql-client
 RUN docker-php-ext-install pdo_mysql
 
+# Drush 6 needs the Console_Table pear.
+RUN pear install Console_Table
+
 # Install Drush using Composer
 RUN composer global require drush/drush:"~6.0.0" --prefer-dist
 

--- a/6.1/Dockerfile
+++ b/6.1/Dockerfile
@@ -6,6 +6,9 @@ MAINTAINER Rob Loach <robloach@gmail.com>
 RUN apt-get update && apt-get install -y mysql-client
 RUN docker-php-ext-install pdo_mysql
 
+# Drush 6 needs the Console_Table pear.
+RUN pear install Console_Table
+
 # Install Drush using Composer
 RUN composer global require drush/drush:"~6.1.0" --prefer-dist
 

--- a/6.2/Dockerfile
+++ b/6.2/Dockerfile
@@ -6,6 +6,9 @@ MAINTAINER Rob Loach <robloach@gmail.com>
 RUN apt-get update && apt-get install -y mysql-client
 RUN docker-php-ext-install pdo_mysql
 
+# Drush 6 needs the Console_Table pear.
+RUN pear install Console_Table
+
 # Install Drush using Composer
 RUN composer global require drush/drush:"~6.2.0" --prefer-dist
 

--- a/6.3/Dockerfile
+++ b/6.3/Dockerfile
@@ -6,6 +6,9 @@ MAINTAINER Rob Loach <robloach@gmail.com>
 RUN apt-get update && apt-get install -y mysql-client
 RUN docker-php-ext-install pdo_mysql
 
+# Drush 6 needs the Console_Table pear.
+RUN pear install Console_Table
+
 # Install Drush using Composer
 RUN composer global require drush/drush:"~6.3.0" --prefer-dist
 

--- a/6.4/Dockerfile
+++ b/6.4/Dockerfile
@@ -6,6 +6,9 @@ MAINTAINER Rob Loach <robloach@gmail.com>
 RUN apt-get update && apt-get install -y mysql-client
 RUN docker-php-ext-install pdo_mysql
 
+# Drush 6 needs the Console_Table pear.
+RUN pear install Console_Table
+
 # Install Drush using Composer
 RUN composer global require drush/drush:"~6.4.0" --prefer-dist
 

--- a/6.5/Dockerfile
+++ b/6.5/Dockerfile
@@ -6,6 +6,9 @@ MAINTAINER Rob Loach <robloach@gmail.com>
 RUN apt-get update && apt-get install -y mysql-client
 RUN docker-php-ext-install pdo_mysql
 
+# Drush 6 needs the Console_Table pear.
+RUN pear install Console_Table
+
 # Install Drush using Composer
 RUN composer global require drush/drush:"~6.5.0" --prefer-dist
 

--- a/6.6/Dockerfile
+++ b/6.6/Dockerfile
@@ -6,6 +6,9 @@ MAINTAINER Rob Loach <robloach@gmail.com>
 RUN apt-get update && apt-get install -y mysql-client
 RUN docker-php-ext-install pdo_mysql
 
+# Drush 6 needs the Console_Table pear.
+RUN pear install Console_Table
+
 # Install Drush using Composer
 RUN composer global require drush/drush:"~6.6.0" --prefer-dist
 


### PR DESCRIPTION
I didn't notice this when I added a Dockerfile for all Composer-able versions of Drush, because apparently `drush --version` will run without it. It's only when I tried to run a command that Drush would try (and fail) to install it. :stuck_out_tongue: