### PR TITLE
Install unzip on base image

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -3,7 +3,7 @@ FROM composer/composer
 MAINTAINER Rob Loach <robloach@gmail.com>
 
 # Add common extensions
-RUN apt-get update && apt-get install -y mysql-client
+RUN apt-get update && apt-get install -y mysql-client unzip
 RUN docker-php-ext-install pdo_mysql
 
 # Update the entry point of the application


### PR DESCRIPTION
We need unzip to be able to extract zip packages downloaded with drush make

Re #7 