### PR TITLE
Add Docker parameters before the actual Drush command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,16 +25,16 @@ docker pull drush/drush:8
 To execute Drush directly, run the container with `docker run`, mounting the `/app` volume:
 
 ``` bash
-docker run drush/drush -v $(pwd):/app
-docker run drush/drush -v $(pwd):/app help
-docker run drush/drush -v $(pwd):/app --version
-docker run drush/drush -v $(pwd):/app status
+docker run -v $(pwd):/app drush/drush
+docker run -v $(pwd):/app drush/drush help
+docker run -v $(pwd):/app drush/drush --version
+docker run -v $(pwd):/app drush/drush status
 ```
 
 If you installed a specific version of Drush, run it with:
 
 ``` bash
-docker run drush/drush:8 -v $(pwd):/app --version
+docker run -v $(pwd):/app drush/drush:8 --version
 ```
 
 ## Development


### PR DESCRIPTION
Hello

I've experienced some issues with the ordering of the Docker arguments as described in the README.

If I do it as described in the README:
```
$ docker run drush/drush -v $(pwd):/app help
The drush command '/path/to/app:/app help' could     [error]
not be found.  Run `drush cache-clear drush` to clear the commandfile
cache if you have installed new extensions.
```

So it seems that the arguments are confusing the Drush command...

```
$ docker run -v $(pwd):/app drush/drush help
```

This seems to work a little better :-)

Greetz!