### PR TITLE
Lets peg to a tag on the backdrush instead of a branch

### DIFF
--- a/backdrop/Dockerfile
+++ b/backdrop/Dockerfile
@@ -2,11 +2,13 @@
 FROM drush/drush:8
 MAINTAINER Mike Pirog
 
+ENV BACKDRUSH_VERSION 0.0.1
+
 # Create a drush image for the Backdrop CMS lovers of the world
 # See https://github.com/backdrop-contrib/drush
 RUN mkdir -p /usr/share/drush/commands/backdrop && \
   cd /usr/share/drush/commands/backdrop && \
-  curl -fsSL "https://github.com/backdrop-contrib/drush/archive/master.tar.gz" | tar xvz --strip-components 1
+  curl -fsSL "https://github.com/backdrop-contrib/drush/archive/${BACKDRUSH_VERSION}.tar.gz" | tar xvz --strip-components 1
 
 # Make sure our cache is wiped and plugins are loaded.
 RUN php /usr/local/bin/drush cache-clear drush


### PR DESCRIPTION
@RobLoach here is a small change to switch over to a tag for the backdrop command files vs a branch. 

This should make the update pathway and maintainability a lot more clear and manageable. 