### PR TITLE
Add Alpine variants for Drush.

### DIFF
--- a/8/alpine/Dockerfile
+++ b/8/alpine/Dockerfile
@@ -1,0 +1,13 @@
+# Drush Docker Container
+FROM drush/drush:base-alpine
+MAINTAINER Rob Loach <robloach@gmail.com>
+
+# Set the Drush version.
+ENV DRUSH_VERSION 8.0.5
+
+# Install Drush 8 with the phar file.
+RUN curl -fsSL -o /usr/local/bin/drush "https://github.com/drush-ops/drush/releases/download/$DRUSH_VERSION/drush.phar" && \
+  chmod +x /usr/local/bin/drush
+
+# Test your install.
+RUN drush core-status

--- a/9/alpine/Dockerfile
+++ b/9/alpine/Dockerfile
@@ -1,0 +1,12 @@
+# Drush Docker Container
+FROM drush/drush:base-alpine
+MAINTAINER Rob Loach <robloach@gmail.com>
+
+# Set the Drush version.
+ENV DRUSH_VERSION 9.0.0-alpha1
+
+# Install Drush using Composer.
+RUN composer global require drush/drush:"$DRUSH_VERSION" --prefer-dist
+
+# Display which version of Drush was installed.
+RUN drush --version

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ build:
 	docker build -t drush/drush:6 6
 	docker build -t drush/drush:backdrop backdrop
 	docker build -t drush/drush:base-alpine base/alpine
-	docker build -t drush/drush-alpine master/alpine
+	docker build -t drush/drush:alpine master/alpine
 	docker build -t drush/drush:9-alpine 9/alpine
 	docker build -t drush/drush:8-alpine 8/alpine
 	docker build -t drush/drush:backdrop-alpine backdrop/alpine
@@ -19,7 +19,7 @@ version:
 	docker run drush/drush:7 --version
 	docker run drush/drush:6 --version
 	docker run drush/drush:backdrop --version
-	docker run drush/drush-alpine --version
+	docker run drush/drush:alpine --version
 	docker run drush/drush:9-alpine --version
 	docker run drush/drush:8-alpine --version
 	docker run drush/drush:backdrop-alpine --version

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,11 @@ build:
 	docker build -t drush/drush:7 7
 	docker build -t drush/drush:6 6
 	docker build -t drush/drush:backdrop backdrop
+	docker build -t drush/drush:base-alpine base/alpine
+	docker build -t drush/drush-alpine master/alpine
+	docker build -t drush/drush:9-alpine 9/alpine
+	docker build -t drush/drush:8-alpine 8/alpine
+	docker build -t drush/drush:backdrop-alpine backdrop/alpine
 
 version:
 	docker run drush/drush --version
@@ -14,6 +19,10 @@ version:
 	docker run drush/drush:7 --version
 	docker run drush/drush:6 --version
 	docker run drush/drush:backdrop --version
+	docker run drush/drush-alpine --version
+	docker run drush/drush:9-alpine --version
+	docker run drush/drush:8-alpine --version
+	docker run drush/drush:backdrop-alpine --version
 
 test:
 	@make version

--- a/backdrop/alpine/Dockerfile
+++ b/backdrop/alpine/Dockerfile
@@ -1,0 +1,15 @@
+# Drush Docker Container for Backdrop CMS
+FROM drush/drush:8-alpine
+MAINTAINER Mike Pirog
+
+# Set the Backdrop Drush version.
+ENV BACKDRUSH_VERSION 0.0.1
+
+# Create a drush image for the Backdrop CMS lovers of the world
+# See https://github.com/backdrop-contrib/drush
+RUN mkdir -p /usr/share/drush/commands/backdrop && \
+  cd /usr/share/drush/commands/backdrop && \
+  curl -fsSL "https://github.com/backdrop-contrib/drush/archive/${BACKDRUSH_VERSION}.tar.gz" | tar xvz --strip-components 1
+
+# Make sure our cache is wiped and plugins are loaded.
+RUN drush cache-clear drush

--- a/base/alpine/Dockerfile
+++ b/base/alpine/Dockerfile
@@ -1,0 +1,25 @@
+# Drush Docker Container
+FROM composer/composer-alpine
+MAINTAINER Rob Loach <robloach@gmail.com>
+
+# Add common extensions
+RUN apk --update add \
+    build-base \
+    libpq \
+    mysql-client \
+    postgresql-client \
+    postgresql-dev \
+    tar && \
+    docker-php-ext-install mysqli pgsql pdo_mysql pdo_pgsql && \
+    apk del build-base postgresql-dev && \
+    rm -rf /var/cache/apk/*
+
+# Add the Redis PHP module.
+RUN git clone --branch="php7" https://github.com/phpredis/phpredis.git /usr/src/php/ext/redis && \
+  # Install the Redis module.
+  docker-php-ext-install redis && \
+  # Test to make sure it's available.
+  php -m && php -r "new Redis();"
+
+# Update the entry point of the application
+ENTRYPOINT ["drush"]

--- a/base/alpine/Dockerfile
+++ b/base/alpine/Dockerfile
@@ -1,5 +1,5 @@
 # Drush Docker Container
-FROM composer/composer-alpine
+FROM composer/composer:alpine
 MAINTAINER Rob Loach <robloach@gmail.com>
 
 # Add common extensions

--- a/master/alpine/Dockerfile
+++ b/master/alpine/Dockerfile
@@ -1,0 +1,12 @@
+# Drush Docker Container
+FROM drush/drush:base-alpine
+MAINTAINER Rob Loach <robloach@gmail.com>
+
+# Set the Drush version..
+ENV DRUSH_VERSION dev-master
+
+# Install Drush using Composer.
+RUN composer global require drush/drush:"$DRUSH_VERSION" --prefer-dist
+
+# Display which version of Drush was installed.
+RUN drush --version


### PR DESCRIPTION
Build passes locally but will need the following P.R. which adds alpine support to composer to pass in travis:

https://github.com/RobLoach/docker-composer/pull/56

Edit: P.R. is merged just waiting for docker tags.

I added postgres support as well since is what I needed, let me know. ^_^

I didn't add 6,7 since it seems they will be dropped soon anyways.