### PR TITLE
Update patch to prevent failed drush make builds.

### DIFF
--- a/base/alpine/Dockerfile
+++ b/base/alpine/Dockerfile
@@ -9,6 +9,7 @@ RUN apk --update add \
     mysql-client \
     postgresql-client \
     postgresql-dev \
+    patch \
     tar && \
     docker-php-ext-install mysqli pgsql pdo_mysql pdo_pgsql && \
     apk del build-base postgresql-dev && \


### PR DESCRIPTION
Looks like something I missed in alpine update but is working for the most part! 

I just ran drush with:

```sh
docker run -v /data/var/www/$DOMAIN:/app drush/drush:alpine make --yes --working-copy --no-gitinfofile ... etc
```

However the patch options needed by drush are not in default alpine.

```sh
patch: unrecognized option: no-backup-if-mismatch                       [notice]
BusyBox v1.24.1 (2015-12-16 08:00:02 GMT) multi-call binary.

Usage: patch [OPTIONS] [ORIGFILE [PATCHFILE]]

	-p,--strip N		Strip N leading components from file names
	-i,--input DIFF		Read DIFF instead of stdin
	-R,--reverse		Reverse patch
	-N,--forward		Ignore already applied patches
	-E,--remove-empty-files	Remove output files if they become empty

Unable to patch drupal with drupal-865536-204.patch.                     [error]
```

Adding patch to the base image fixed the issue ^_^.