### PR TITLE
Install SQLite packages for PHP 7

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -6,6 +6,14 @@ MAINTAINER Rob Loach <robloach@gmail.com>
 RUN apt-get update && apt-get install -y mysql-client
 RUN docker-php-ext-install pdo_mysql
 
+# SQLite support
+RUN echo "deb http://ftp.hosteurope.de/mirror/packages.dotdeb.org/ stable all" >> /etc/apt/sources.list && echo "deb-src http://ftp.hosteurope.de/mirror/packages.dotdeb.org/ stable all" >> /etc/apt/sources.list
+
+RUN wget https://www.dotdeb.org/dotdeb.gpg && apt-key add dotdeb.gpg && apt-get update
+
+RUN apt-get install -y libsqlite3-dev sqlite3 php7.0-sqlite3 && \
+    docker-php-ext-install pdo_sqlite
+
 # Add the Redis PHP module.
 RUN git clone --branch="php7" https://github.com/phpredis/phpredis.git /usr/src/php/ext/redis && \
   # Install the Redis module.


### PR DESCRIPTION
This enables SQLite support. I've tested with Drush 8.