### PR TITLE
Update Backdrush image with new 0.0.2 magix

### DIFF
--- a/backdrop/Dockerfile
+++ b/backdrop/Dockerfile
@@ -3,7 +3,7 @@ FROM drush/drush:8
 MAINTAINER Mike Pirog
 
 # Set the Backdrop Drush version.
-ENV BACKDRUSH_VERSION 0.0.1
+ENV BACKDRUSH_VERSION 0.0.2
 
 # Create a drush image for the Backdrop CMS lovers of the world
 # See https://github.com/backdrop-contrib/drush

--- a/backdrop/alpine/Dockerfile
+++ b/backdrop/alpine/Dockerfile
@@ -3,7 +3,7 @@ FROM drush/drush:8-alpine
 MAINTAINER Mike Pirog
 
 # Set the Backdrop Drush version.
-ENV BACKDRUSH_VERSION 0.0.1
+ENV BACKDRUSH_VERSION 0.0.2
 
 # Create a drush image for the Backdrop CMS lovers of the world
 # See https://github.com/backdrop-contrib/drush


### PR DESCRIPTION
@RobLoach wanted to update the back-drush image before the BADCamp. 

Can haz mergings? 