### PR TITLE
Update to latest Drush 8

### DIFF
--- a/8/Dockerfile
+++ b/8/Dockerfile
@@ -3,7 +3,7 @@ FROM drush/drush:base
 MAINTAINER Rob Loach <robloach@gmail.com>
 
 # Set the Drush version.
-ENV DRUSH_VERSION 8.1.2
+ENV DRUSH_VERSION 8.1.15
 
 # Install Drush 8 with the phar file.
 RUN curl -fsSL -o /usr/local/bin/drush "https://github.com/drush-ops/drush/releases/download/$DRUSH_VERSION/drush.phar" && \

--- a/8/alpine/Dockerfile
+++ b/8/alpine/Dockerfile
@@ -3,7 +3,7 @@ FROM drush/drush:base-alpine
 MAINTAINER Rob Loach <robloach@gmail.com>
 
 # Set the Drush version.
-ENV DRUSH_VERSION 8.1.2
+ENV DRUSH_VERSION 8.1.15
 
 # Install Drush 8 with the phar file.
 RUN curl -fsSL -o /usr/local/bin/drush "https://github.com/drush-ops/drush/releases/download/$DRUSH_VERSION/drush.phar" && \

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && apt-get install -y mysql-client
 RUN docker-php-ext-install pdo_mysql
 
 # Add the Redis PHP module.
-RUN git clone --branch="php7" https://github.com/phpredis/phpredis.git /usr/src/php/ext/redis && \
+RUN git clone --branch="master" https://github.com/phpredis/phpredis.git /usr/src/php/ext/redis && \
   # Install the Redis module.
   docker-php-ext-install redis && \
   # Test to make sure it's available.

--- a/base/alpine/Dockerfile
+++ b/base/alpine/Dockerfile
@@ -17,7 +17,7 @@ RUN apk --update add \
     rm -rf /var/cache/apk/*
 
 # Add the Redis PHP module.
-RUN git clone --branch="php7" https://github.com/phpredis/phpredis.git /usr/src/php/ext/redis && \
+RUN git clone --branch="master" https://github.com/phpredis/phpredis.git /usr/src/php/ext/redis && \
   # Install the Redis module.
   docker-php-ext-install redis && \
   # Test to make sure it's available.


### PR DESCRIPTION
Bumping the Drush 8 version number so we have compatibility with Drupal 8.4+. This is needed for some legacy Kalabox users.