### PR TITLE
Update Drush 8 and 9

### DIFF
--- a/8/Dockerfile
+++ b/8/Dockerfile
@@ -3,7 +3,7 @@ FROM drush/drush:base
 MAINTAINER Rob Loach <robloach@gmail.com>
 
 # Set the Drush version.
-ENV DRUSH_VERSION 8.1.15
+ENV DRUSH_VERSION 8.1.16
 
 # Install Drush 8 with the phar file.
 RUN curl -fsSL -o /usr/local/bin/drush "https://github.com/drush-ops/drush/releases/download/$DRUSH_VERSION/drush.phar" && \

--- a/8/alpine/Dockerfile
+++ b/8/alpine/Dockerfile
@@ -3,7 +3,7 @@ FROM drush/drush:base-alpine
 MAINTAINER Rob Loach <robloach@gmail.com>
 
 # Set the Drush version.
-ENV DRUSH_VERSION 8.1.15
+ENV DRUSH_VERSION 8.1.16
 
 # Install Drush 8 with the phar file.
 RUN curl -fsSL -o /usr/local/bin/drush "https://github.com/drush-ops/drush/releases/download/$DRUSH_VERSION/drush.phar" && \

--- a/9/Dockerfile
+++ b/9/Dockerfile
@@ -3,7 +3,7 @@ FROM drush/drush:base
 MAINTAINER Rob Loach <robloach@gmail.com>
 
 # Set the Drush version.
-ENV DRUSH_VERSION 9.0.0-alpha1
+ENV DRUSH_VERSION 9.2.1
 
 # Install Drush using Composer.
 RUN composer global require drush/drush:"$DRUSH_VERSION" --prefer-dist

--- a/9/alpine/Dockerfile
+++ b/9/alpine/Dockerfile
@@ -3,7 +3,7 @@ FROM drush/drush:base-alpine
 MAINTAINER Rob Loach <robloach@gmail.com>
 
 # Set the Drush version.
-ENV DRUSH_VERSION 9.0.0-alpha1
+ENV DRUSH_VERSION 9.2.1
 
 # Install Drush using Composer.
 RUN composer global require drush/drush:"$DRUSH_VERSION" --prefer-dist


### PR DESCRIPTION
This updates Drush 8 to versioin 8.1.16 (released Feb 6 2018) and Drush 9 to version 9.2.1 (released Feb 27 2018).