### PR TITLE
Add in PHP memcached extension

### DIFF
--- a/base/alpine/Dockerfile
+++ b/base/alpine/Dockerfile
@@ -1,6 +1,6 @@
 # Drush Docker Container
 FROM composer/composer:alpine
-MAINTAINER Rob Loach <robloach@gmail.com>
+MAINTAINER Moses Liao <moses.liao.sd@gmail.com>
 
 # Add common extensions
 RUN apk --update add \
@@ -22,6 +22,20 @@ RUN git clone --branch="master" https://github.com/phpredis/phpredis.git /usr/sr
   docker-php-ext-install redis && \
   # Test to make sure it's available.
   php -m && php -r "new Redis();"
+
+# Add in Memcached PHP module
+ENV MEMCACHED_DEPS zlib-dev libmemcached-dev cyrus-sasl-dev
+RUN apk add --no-cache --update libmemcached-libs zlib
+RUN set -xe \
+    && apk add --no-cache --update --virtual .phpize-deps $PHPIZE_DEPS \
+    && apk add --no-cache --update --virtual .memcached-deps $MEMCACHED_DEPS \
+    && pecl install memcached \
+    && echo "extension=memcached.so" > /usr/local/etc/php/conf.d/20_memcached.ini \
+    && rm -rf /usr/share/php7 \
+    && rm -rf /tmp/* \
+    && apk del .memcached-deps .phpize-deps \
+    # Test to make sure it's available
+    && php -m && php -r "new Memcached();"
 
 # Update the entry point of the application
 ENTRYPOINT ["drush"]


### PR DESCRIPTION
I am adding memcached extension to this docker image as it keeps showing up the error

```
WD memcache: You must enable the PHP memcache (recommended) or memcached extension to use memcache.inc.                                                                                    [error]
WD memcache: Failed to connect to memcache server: memcached:11211                                                                                                                         [error]
```