### PR TITLE
Uses PHP 7 as the base instead of composer

### DIFF
--- a/php7/Dockerfile
+++ b/php7/Dockerfile
@@ -92,4 +92,4 @@ WORKDIR /app
 #
 
 # Update the entry point of the application
-# ENTRYPOINT ["drush"]
+ENTRYPOINT ["drush"]

--- a/php7/Dockerfile
+++ b/php7/Dockerfile
@@ -1,0 +1,95 @@
+# Drush Docker Container
+FROM php:7.2.13-zts-alpine3.8
+
+MAINTAINER Moses Liao <moses.liao.sd@gmail.com>
+
+RUN apk --no-cache add git subversion openssh mercurial tini bash patch zip unzip
+
+RUN echo "memory_limit=-1" > "$PHP_INI_DIR/conf.d/memory-limit.ini" \
+ && echo "date.timezone=${PHP_TIMEZONE:-UTC}" > "$PHP_INI_DIR/conf.d/date_timezone.ini"
+
+RUN apk add --no-cache --virtual .build-deps zlib-dev \
+ && docker-php-ext-install zip \
+ && runDeps="$( \
+    scanelf --needed --nobanner --format '%n#p' --recursive /usr/local/lib/php/extensions \
+    | tr ',' '\n' \
+    | sort -u \
+    | awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
+    )" \
+ && apk add --virtual .composer-phpext-rundeps $runDeps \
+ && apk del .build-deps
+
+ENV COMPOSER_ALLOW_SUPERUSER 1
+ENV COMPOSER_HOME /tmp
+ENV COMPOSER_VERSION 1.8.0
+
+RUN curl --silent --fail --location --retry 3 --output /tmp/installer.php --url https://raw.githubusercontent.com/composer/getcomposer.org/b107d959a5924af895807021fcef4ffec5a76aa9/web/installer \
+ && php -r " \
+    \$signature = '544e09ee996cdf60ece3804abc52599c22b1f40f4323403c44d44fdfdd586475ca9813a858088ffbc1f233e9b180f061'; \
+    \$hash = hash('SHA384', file_get_contents('/tmp/installer.php')); \
+    if (!hash_equals(\$signature, \$hash)) { \
+        unlink('/tmp/installer.php'); \
+        echo 'Integrity check failed, installer is either corrupt or worse.' . PHP_EOL; \
+        exit(1); \
+    }" \
+ && php /tmp/installer.php --no-ansi --install-dir=/usr/bin --filename=composer --version=${COMPOSER_VERSION} \
+ && composer --ansi --version --no-interaction \
+ && rm -rf /tmp/* /tmp/.htaccess
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+
+# CMD ["composer"]
+
+# Add common extensions
+RUN apk --update add \
+    build-base \
+    libpq \
+    mysql-client \
+    postgresql-client \
+    postgresql-dev \
+    php7-pear \
+    patch \
+    tar && \
+    docker-php-ext-install mysqli pgsql pdo_mysql pdo_pgsql && \
+    apk del build-base postgresql-dev && \
+    rm -rf /var/cache/apk/*
+
+# Add the Redis PHP module.
+RUN git clone --branch="master" https://github.com/phpredis/phpredis.git /usr/src/php/ext/redis && \
+  # Install the Redis module.
+  docker-php-ext-install redis && \
+  # Test to make sure it's available.
+  php -m && php -r "new Redis();"
+
+# Add in Memcached PHP module
+ENV MEMCACHED_DEPS zlib-dev libmemcached-dev cyrus-sasl-dev
+RUN apk add --no-cache --update libmemcached-libs zlib
+RUN set -xe \
+    && apk add --no-cache --update --virtual .phpize-deps $PHPIZE_DEPS \
+    && apk add --no-cache --update --virtual .memcached-deps $MEMCACHED_DEPS \
+    && pecl install memcached \
+    && echo "extension=memcached.so" > /usr/local/etc/php/conf.d/20_memcached.ini \
+    && rm -rf /usr/share/php7 \
+    && rm -rf /tmp/* \
+    && apk del .memcached-deps .phpize-deps \
+    # Test to make sure it's available
+    && php -m && php -r "new Memcached();"
+
+ENV DRUSH_VERSION 8.1.17
+
+# Install Drush 8 with the phar file.
+RUN curl -fsSL -o /usr/local/bin/drush "https://github.com/drush-ops/drush/releases/download/$DRUSH_VERSION/drush.phar" && \
+  chmod +x /usr/local/bin/drush
+
+RUN php -v
+
+# Test your install.
+RUN drush core-status
+
+WORKDIR /app
+#
+# ENTRYPOINT ["/bin/sh", "/docker-entrypoint.sh"]
+#
+
+# Update the entry point of the application
+# ENTRYPOINT ["drush"]

--- a/php7/docker-entrypoint.sh
+++ b/php7/docker-entrypoint.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+isCommand() {
+  for cmd in \
+    "about" \
+    "archive" \
+    "browse" \
+    "check-platform-reqs" \
+    "clear-cache" \
+    "clearcache" \
+    "config" \
+    "create-project" \
+    "depends" \
+    "diagnose" \
+    "dump-autoload" \
+    "dumpautoload" \
+    "exec" \
+    "global" \
+    "help" \
+    "home" \
+    "info" \
+    "init" \
+    "install" \
+    "licenses" \
+    "list" \
+    "outdated" \
+    "prohibits" \
+    "remove" \
+    "require" \
+    "run-script" \
+    "search" \
+    "self-update" \
+    "selfupdate" \
+    "show" \
+    "status" \
+    "suggests" \
+    "update" \
+    "upgrade" \
+    "validate" \
+    "why" \
+    "why-not"
+  do
+    if [ -z "${cmd#"$1"}" ]; then
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+# check if the first argument passed in looks like a flag
+if [ "$(printf %c "$1")" = '-' ]; then
+  set -- /sbin/tini -- composer "$@"
+# check if the first argument passed in is composer
+elif [ "$1" = 'composer' ]; then
+  set -- /sbin/tini -- "$@"
+# check if the first argument passed in matches a known command
+elif isCommand "$1"; then
+  set -- /sbin/tini -- composer "$@"
+fi
+
+exec "$@"


### PR DESCRIPTION
The base still uses the `composer/composer` as the container to build from which uses PHP5 and is depreciated. I suggest we build it from the original PHP7 instead.