### PR TITLE
Updating base to be composer image based instead of composer/composer…

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,10 +1,10 @@
 # Drush Docker Container
-FROM composer/composer
+FROM composer
 MAINTAINER Rob Loach <robloach@gmail.com>
 
 # Add common extensions
-RUN apt-get update && apt-get install -y mysql-client
-RUN docker-php-ext-install pdo_mysql
+RUN apk add --update mysql-client libpq postgresql-dev postgresql-client
+RUN docker-php-ext-install pdo_mysql pdo_pgsql
 
 # Add the Redis PHP module.
 RUN git clone --branch="master" https://github.com/phpredis/phpredis.git /usr/src/php/ext/redis && \


### PR DESCRIPTION
I set out to provide postgres support, then realized it was depending on composer/composer which is no longer supported. Updated the base image to use just composer main package then installs postgres.